### PR TITLE
Add builder class name as a suffix to cache

### DIFF
--- a/app/helpers/katalyst/navigation/frontend_helper.rb
+++ b/app/helpers/katalyst/navigation/frontend_helper.rb
@@ -17,7 +17,7 @@ module Katalyst
 
         return unless menu&.published_version&.present?
 
-        cache menu.published_version do
+        cache "#{menu.published_version}_#{builder.class.name}" do
           concat builder.render(menu.published_tree)
         end
       end


### PR DESCRIPTION
fixes https://github.com/katalyst/navigation/issues/18